### PR TITLE
Add Example Files for Docker

### DIFF
--- a/.dockerignore.example
+++ b/.dockerignore.example
@@ -1,9 +1,16 @@
+# Exclude version control files
+.git
+.gitignore
+
+# Exclude unnecessary development and testing files
+*_test.go
+.idea/
+.vscode/
+/build/
+
 # Exclude all environment files
 *.env
 .env.*
-!.env.example
-!.env.*.example
-
 
 # Binaries
 *.exe
@@ -31,31 +38,22 @@ tmp/
 
 # Dependency directories
 /vendor/
-/go.sum
-
-# Generated files
-/swagger/
-/internal/routers/docs/
 
 # Build artifacts
 /build/
-
-# Air hot reload artifacts
-/.air.toml
 
 # Docker artifacts
 .DS_Store
 docker-compose.yml
 Dockerfile
 Dockerfile.*
-!Dockerfile.staging.uat.example
-!Dockerfile.dev.example
-!Dockerfile.postgres.example
-
 docker-compose.override.yml
 .dockerignore
-!.dockerignore.example
-
+.dockerignore.example
 
 # Logs
 *.log
+
+# MISC
+LICENSE
+README.md

--- a/Dockerfile.dev.example
+++ b/Dockerfile.dev.example
@@ -1,0 +1,21 @@
+# Start from the official Go image
+FROM golang:latest
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Install air
+RUN go install github.com/cosmtrek/air@latest
+
+# Copy the Go module files and download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the source code into the container
+COPY . .
+
+# Expose port 8080 to the outside world
+EXPOSE 8080
+
+# Run the application with Air
+CMD ["air"]

--- a/Dockerfile.staging.uat.example
+++ b/Dockerfile.staging.uat.example
@@ -1,0 +1,20 @@
+# Start from the official Go image
+FROM golang:latest
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the Go module files and download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the source code into the container
+COPY . .
+
+RUN go build -o ./cmd/habit_tracker/main ./cmd/habit_tracker/main.go
+
+# Expose port 8080 to the outside world
+EXPOSE 8080
+
+# Run the binary app
+CMD ["./cmd/habit_tracker/main"]

--- a/internal/database/postgres/Dockerfile.postgres.example
+++ b/internal/database/postgres/Dockerfile.postgres.example
@@ -1,0 +1,5 @@
+# Start from the official PostgreSQL image
+FROM postgres:latest
+
+# Expose the PostgreSQL port
+EXPOSE 5432


### PR DESCRIPTION
* Modify `.gitignore` file to keep track of example files ignored by patterns.

* Add following files:
	- `.dockerignore.example`
	- `Dockerfile.dev.example`
	- `Dockerfile.staging.uat.example`
	- `internal/database/postgres/Dockerfile.postgres.example`

Fixes: #5c00f36

Issue URL: https://app.roundrush.com/ld/BET/development?issue=BET-958&tab=comments&users=56c4fda4-ac0a-11ee-887c-4b3805a63eb2